### PR TITLE
Fix kaomoji layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,6 +179,9 @@ function renderEmojis() {
       category.emojis.forEach(emoji => {
         const emojiItem = document.createElement('div');
         emojiItem.className = 'emoji-item';
+        if (category.id === 'kaomoji') {
+          emojiItem.classList.add('kaomoji-item');
+        }
         emojiItem.setAttribute('data-emoji', JSON.stringify(emoji));
         emojiItem.innerHTML = `
           <span class="emoji-char">${emoji.emoji}</span>

--- a/app.test.js
+++ b/app.test.js
@@ -146,4 +146,10 @@ describe('kaomoji grid responsiveness', () => {
     const grid = document.querySelector('.emoji-grid');
     expect(grid.classList.contains('kaomoji-grid')).toBe(true);
   });
+
+  test('adds kaomoji-item class to emoticon entries', () => {
+    renderEmojis();
+    const items = document.querySelectorAll('.kaomoji-item');
+    expect(items.length).toBeGreaterThan(0);
+  });
 });

--- a/style.css
+++ b/style.css
@@ -741,17 +741,23 @@ select.form-control {
 
 /* Kaomoji grid adjusts to emoticon length */
 .kaomoji-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  /* Flex layout lets each emoticon size itself */
+  display: flex;
+  flex-wrap: wrap;
   gap: var(--space-12);
 }
 
-.kaomoji-page .kaomoji-grid .emoji-item {
+.kaomoji-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   height: auto;
-  min-height: 60px;
+  min-height: 0;
   white-space: normal;
-  padding: var(--space-8) var(--space-12);
+  padding: var(--space-4) var(--space-8);
   font-size: var(--font-size-xl);
+  background: none;
+  border: none;
 }
 
 .emoji-item {


### PR DESCRIPTION
## Summary
- switch kaomoji section to use flex layout
- add `.kaomoji-item` style to remove box styling
- apply new class when rendering kaomojis
- test that new class is applied

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848dd48abac83218a5195657532abbb